### PR TITLE
fix lens shift not updated on throw ratio change

### DIFF
--- a/projector.py
+++ b/projector.py
@@ -286,6 +286,11 @@ def update_throw_ratio(proj_settings, context):
         nodes['Mapping.001'].inputs[3].default_value[1] = 1 / \
             throw_ratio * inverted_aspect_ratio
 
+    # Update lens shift because it depends on the throw ratio.
+    update_lens_shift(proj_settings, context)
+
+    
+
 
 def update_lens_shift(proj_settings, context):
     """


### PR DESCRIPTION
This PR triggers the lens shift to update after the throw ratio changes.

Thank you @drlight-code for reporting this issue #27.